### PR TITLE
Fix coach week view phase lookup — use date range

### DIFF
--- a/components/PlanClient.tsx
+++ b/components/PlanClient.tsx
@@ -441,10 +441,12 @@ export default function PlanClient({ plan, phases, races, library, today }: Prop
   const [weekIdx, setWeekIdx] = useState(initialWeekIdx)
 
   const { weekNum, entries: weekEntries } = weeks[weekIdx] ?? { weekNum: 1, entries: [] as PlannedWorkout[] }
-  const phase = phases.find(p => weekEntries.some(e => e.phase === p.name)) ?? phases[0]
-  const totalMiles = weekEntries.reduce((s, e) => s + (e.distance ?? 0), 0)
   const weekStart = weekEntries[0]?.date ?? ''
   const weekEnd = weekEntries[weekEntries.length - 1]?.date ?? ''
+  const phase = phases.find(p => p.startDate <= weekStart && p.endDate >= weekEnd)
+    ?? phases.find(p => p.startDate <= weekStart && p.endDate >= weekStart)
+    ?? null
+  const totalMiles = weekEntries.reduce((s, e) => s + (e.distance ?? 0), 0)
 
   const sortedRaces = useMemo(() => [...races].sort((a, b) => a.date.localeCompare(b.date)), [races])
 


### PR DESCRIPTION
## What this fixes

The coach week view (Plan tab → Weeks) was showing the wrong phase name and description for weeks at phase boundaries. Navigating to the week of May 25 showed "BASE BUILDING 1" instead of "SETTING UP THE BASE".

## Root cause

Phase lookup was matching plan entry `phase` field values against phase names, then falling back to `phases[0]` when no match was found. Any week where entries had a mismatched or missing phase field silently showed the first phase in the array.

## Fix

Replaced with date-range matching — the same strategy used in the athlete week view (WeekClient.tsx). Moved `weekStart` / `weekEnd` above the phase lookup so they're available.

## How to test

1. Go to Plan tab → Weeks
2. Navigate to the week of May 25 — should show "Setting up the base" with its description
3. Navigate through other phase boundaries — each week should show the correct phase

closes #32
