### PR TITLE
Sport-split mileage and fix duration decimals in athlete week view

### DIFF
--- a/components/WeekClient.tsx
+++ b/components/WeekClient.tsx
@@ -114,8 +114,9 @@ export default function WeekClient({
   const isCurrentWeek = viewWeekStart === initialWeekStart
 
   const plannedMiles = weekPlan.reduce((s, e) => s + (e.distance ?? 0), 0)
-  const actualMiles = weekLog.reduce((s, e) => s + (e.distance ?? 0), 0)
-  const pct = plannedMiles > 0 ? Math.min(100, Math.round((actualMiles / plannedMiles) * 100)) : 0
+  const runMiles = weekLog.filter(e => /run/i.test(e.activityType)).reduce((s, e) => s + (e.distance ?? 0), 0)
+  const bikeMiles = weekLog.filter(e => /ride/i.test(e.activityType)).reduce((s, e) => s + (e.distance ?? 0), 0)
+  const pct = plannedMiles > 0 ? Math.min(100, Math.round((runMiles / plannedMiles) * 100)) : 0
 
   async function navigateWeek(newStart: string) {
     if (newStart < minWeekStart || newStart > maxWeekStart) return
@@ -203,7 +204,10 @@ export default function WeekClient({
       <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-4 mb-4">
         <div className="flex justify-between items-baseline mb-2">
           <div className="text-sm font-semibold text-gray-700">Mileage</div>
-          <div className="text-sm text-gray-500">{actualMiles.toFixed(1)} / {plannedMiles.toFixed(1)} mi</div>
+          <div className="text-sm text-gray-500">
+            Run {runMiles.toFixed(1)} / {plannedMiles.toFixed(1)} mi
+            {bikeMiles > 0 && <span className="ml-2 text-gray-400">· Bike {bikeMiles.toFixed(1)} mi</span>}
+          </div>
         </div>
         <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
           <div
@@ -248,7 +252,7 @@ export default function WeekClient({
                     <div className="text-right shrink-0">
                       <div className="text-sm font-semibold text-emerald-600">{totalActualMi.toFixed(1)} mi</div>
                       <div className="text-xs text-gray-400">
-                        {dayLogs.reduce((s, l) => s + (l.duration ?? 0), 0)} min
+                        {dayLogs.reduce((s, l) => s + (l.duration ?? 0), 0).toFixed(1)} min
                       </div>
                     </div>
                   ) : isPast && entry.dayType !== 'Rest' ? (


### PR DESCRIPTION
## What this fixes

The athlete week view mileage card was combining run and bike miles into one total, making planned vs actual comparison meaningless (a week with 10 mi running + 22 mi bike commuting showed as 32 mi). Duration on day cards showed floating point noise (88.6999999999999 min).

## Changes

- **Mileage card**: shows "Run X.X / Y.Y mi" comparing run miles against planned. Bike miles appear as a secondary stat ("· Bike X.X mi") only if there are bike activities that week.
- **Progress bar**: now correctly based on run miles vs planned (not combined total)
- **Duration**: rounded to 1 decimal place

## How to test

1. Navigate to the Week view
2. Week 4 (May 18–24) — should show run miles and bike miles separately, progress bar based on runs only
3. Check Monday — duration should show one decimal (e.g. "88.7 min" not "88.6999...")
4. Navigate to a run-only week — no bike line should appear

closes #27
