### PR TITLE
Show phase description in athlete week view

### DIFF
--- a/components/WeekClient.tsx
+++ b/components/WeekClient.tsx
@@ -201,6 +201,13 @@ export default function WeekClient({
         )}
       </header>
 
+      {currentPhase?.goal && (
+        <div className="bg-blue-50 border border-blue-100 rounded-2xl p-4 mb-4">
+          <div className="text-xs font-bold text-blue-600 tracking-wide mb-1">{currentPhase.name.toUpperCase()}</div>
+          <div className="text-sm text-gray-700 leading-relaxed">{currentPhase.goal}</div>
+        </div>
+      )}
+
       <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-4 mb-4">
         <div className="flex justify-between items-baseline mb-2">
           <div className="text-sm font-semibold text-gray-700">Mileage</div>


### PR DESCRIPTION
## Stories covered

**#28 — Fix phase lookup at boundaries (verified, no code change needed)**
The athlete week view already uses date-range matching (WeekClient.tsx lines 105-107). Navigating to May 25 correctly resolves "Setting up the base" — the bug was only in the coach view (fixed in PR #36).

**#29 — Show phase description in athlete week view**
Adds a phase context card between the week header and the mileage card. Shows the phase name (uppercase blue) and the goal/description text. Only renders when the current phase has a goal — no empty card shown.

## How to test

1. Go to the Week view (`/week`)
2. Navigate to any week — a blue card should appear below the header showing the phase name and description
3. Navigate to May 25 week — should show "SETTING UP THE BASE" with its description
4. Navigate to a week with no phase goal set — card should not appear

closes #28
closes #29
