### PR TITLE
Coach tab and profile — story #41

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,57 @@ All sheet fetches use `{ next: { revalidate: 300 } }`. Manually editing the shee
 ### Library sport normalization
 The Workout Library uses "Running" as the sport name; the app normalizes to "Run" via `normalizeSport()` in `lib/sheets.ts`. Without this, the library picker shows no workouts for Run days.
 
+## Development Workflow
+
+Claude is the primary developer on this project. Each new Claude session is a fresh context — treat it like a new developer joining the team. The GitHub history, PRs, and issues are the institutional memory that orients each session.
+
+### PR-per-story workflow
+Every story ships as a PR, not a direct commit to `main`:
+
+1. **Pick a story** from the open GitHub issues (e.g. #27)
+2. **Branch**: `story/27-sport-split-mileage` (pattern: `story/<number>-<short-slug>`)
+3. **Build** the story, referencing AC from the issue
+4. **Self-review** before opening the PR (see below)
+5. **Open PR** with `closes #27` in the body — GitHub auto-links commits and auto-closes on merge
+6. **Vercel builds a preview URL** — Lou tests on mobile before anything hits production
+7. **Prompt Lou to run `/ultrareview`** on any PR touching more than one file (see below)
+8. **Lou reviews and merges** — production deploys automatically
+
+### Self-review before every PR (mandatory)
+Before opening a PR, Claude must review its own diff and check:
+- [ ] Does the implementation match every AC in the story?
+- [ ] Are there edge cases the AC doesn't cover that could break in production?
+- [ ] Any security issues — unvalidated input, exposed secrets, injection risks?
+- [ ] Consistent with project conventions (server components, sheet write patterns, Tailwind classes)?
+- [ ] TypeScript clean — run `npx tsc --noEmit` and confirm zero errors
+- [ ] No dead code, debug logs, or temporary hacks left in
+
+If anything fails, fix it before opening the PR.
+
+### `/ultrareview` rule
+After opening a PR that touches **more than one file**, always tell Lou:
+
+> "This PR touches X files. Run `/ultrareview <PR number>` before merging for an independent code review."
+
+Lou runs `/ultrareview` in the Claude Code interface — it launches a multi-agent review of the PR diff and reports back. This is the code review step that catches what functional testing misses.
+
+Single-file PRs (like a one-line bug fix) can skip `/ultrareview` at Lou's discretion.
+
+### Lou's role — BA + QA, not code reviewer
+Lou reviews features functionally (does it work on mobile?) and as a BA (does it match what was specified?). Claude is responsible for code quality, security, and implementation correctness — that's what self-review and `/ultrareview` are for.
+
+### Why this matters
+- A fresh Claude session runs `gh pr list` and `gh issue list` to orient immediately
+- Lou reviews every change before it reaches production (Vercel preview URL)
+- Git history stays clean and traceable — each commit links to a story and its acceptance criteria
+- Rollback is clean — a story is the unit of change
+
+### GitHub label ownership
+The `ready-to-build` label is Lou's to apply — it means Lou has reviewed the story and cleared it to build. Claude must never add this label when creating or editing issues. Use only descriptive labels (`story`, `epic`, `coaching`, `bug`, `backlog`, etc.) when filing issues.
+
+### Never commit directly to main
+All code changes go through a PR. The only exception is CLAUDE.md updates and documentation.
+
 ## Deployment Status
 - **Live at**: https://trainerv1.vercel.app
 - **Vercel project**: fouloxs-projects/trainer_v1 (linked via CLI, auto-deploys from `main`)
@@ -159,6 +210,14 @@ The Workout Library uses "Running" as the sport name; the app normalizes to "Run
 - Mobile-first: this is used on the phone during/after runs
 - Single user for now (Lou), but data model and auth built for multi-user expansion
 - Plan building happens in the Google Sheet — the app is read + light write (log a workout, swap a workout)
+
+## Product Vision
+
+This is not a generic training app. Apps like Runna give athletes an algorithm with no real coach behind it. This app is different: it pairs real coaching intelligence with AI — the coach sets intent, the AI amplifies it, the athlete feels the difference.
+
+The goal is to build something athletes and coaches genuinely trust, where the AI voice sounds like a coach who knows you, not a fitness chatbot. Every feature decision should serve that vision.
+
+**Hold the quality bar high.** If a feature feels generic, it probably is. Ask why this week's note matters to *this* athlete on *this* day. That's the standard.
 
 ## Future Direction
 - Multi-athlete / multi-coach support (Clerk orgs)

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -3,8 +3,8 @@
 import { revalidatePath } from 'next/cache'
 import { fetchPlanData, fetchTrainingData, fetchTrainingLog } from '@/lib/sheets'
 import { generateCoachingNote, generateRestDayNote, generatePostWorkoutNote, generatePTSummaryForRange, generateWeekReview, sendCheckInMessage } from '@/lib/ai'
-import { getCoachingNote, setCoachingNote, getPostCoachingNote, setPostCoachingNote, getCheckIn, setCheckIn, getWeekReview, setWeekReview } from '@/lib/kv'
-import type { CoachingNote, WeekReview, CheckInMessage } from '@/lib/data'
+import { getCoachingNote, setCoachingNote, getPostCoachingNote, setPostCoachingNote, getCheckIn, setCheckIn, getWeekReview, setWeekReview, setCoachProfile } from '@/lib/kv'
+import type { CoachingNote, WeekReview, CheckInMessage, CoachProfile } from '@/lib/data'
 
 export async function fetchCoachingNoteForDate(date: string): Promise<CoachingNote | null> {
   try {
@@ -578,4 +578,13 @@ export async function createFeedbackIssue(data: {
 
   const issue = await res.json() as { html_url: string }
   return { url: issue.html_url }
+}
+
+export async function saveCoachProfile(profile: CoachProfile): Promise<{ success: boolean; error?: string }> {
+  try {
+    await setCoachProfile({ ...profile, updatedAt: new Date().toISOString() })
+    return { success: true }
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Failed to save profile' }
+  }
 }

--- a/app/coach/page.tsx
+++ b/app/coach/page.tsx
@@ -1,0 +1,7 @@
+import { getCoachProfile } from '@/lib/kv'
+import CoachClient from '@/components/CoachClient'
+
+export default async function CoachPage() {
+  const profile = await getCoachProfile()
+  return <CoachClient initialProfile={profile} />
+}

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -1,48 +1,35 @@
 'use client'
 
-import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Sun, CalendarDays, BarChart2, BookOpen, Flag } from 'lucide-react'
-import FeedbackDrawer from './FeedbackDrawer'
+import { Sun, CalendarDays, BarChart2, BookOpen, ClipboardList } from 'lucide-react'
 
 const tabs = [
   { href: '/',        label: 'Today',   icon: Sun },
   { href: '/week',    label: 'Week',    icon: BarChart2 },
   { href: '/plan',    label: 'Plan',    icon: CalendarDays },
   { href: '/library', label: 'Library', icon: BookOpen },
+  { href: '/coach',   label: 'Coach',   icon: ClipboardList },
 ]
 
 export default function BottomNav() {
   const pathname = usePathname()
-  const [feedbackOpen, setFeedbackOpen] = useState(false)
 
   return (
-    <>
-      <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 flex safe-area-inset-bottom">
-        {tabs.map(({ href, label, icon: Icon }) => {
-          const active = pathname === href
-          return (
-            <Link
-              key={href}
-              href={href}
-              className={`flex-1 flex flex-col items-center py-3 gap-1 text-xs font-medium transition-colors ${active ? 'text-blue-600' : 'text-gray-400'}`}
-            >
-              <Icon size={22} strokeWidth={active ? 2.5 : 1.75} />
-              {label}
-            </Link>
-          )
-        })}
-        <button
-          onClick={() => setFeedbackOpen(true)}
-          className="flex-1 flex flex-col items-center py-3 gap-1 text-xs font-medium text-gray-400 transition-colors hover:text-gray-600"
-        >
-          <Flag size={22} strokeWidth={1.75} />
-          Feedback
-        </button>
-      </nav>
-
-      <FeedbackDrawer open={feedbackOpen} onClose={() => setFeedbackOpen(false)} />
-    </>
+    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 flex safe-area-inset-bottom">
+      {tabs.map(({ href, label, icon: Icon }) => {
+        const active = pathname === href || (href !== '/' && pathname.startsWith(href))
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={`flex-1 flex flex-col items-center py-3 gap-1 text-xs font-medium transition-colors ${active ? 'text-blue-600' : 'text-gray-400'}`}
+          >
+            <Icon size={22} strokeWidth={active ? 2.5 : 1.75} />
+            {label}
+          </Link>
+        )
+      })}
+    </nav>
   )
 }

--- a/components/CoachClient.tsx
+++ b/components/CoachClient.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { Flag, X, Plus } from 'lucide-react'
+import type { CoachProfile } from '@/lib/data'
+import { saveCoachProfile } from '@/app/actions'
+import FeedbackDrawer from './FeedbackDrawer'
+
+const EMPTY_PROFILE: CoachProfile = {
+  name: '',
+  philosophy: '',
+  influences: [],
+  credentials: '',
+  updatedAt: '',
+}
+
+export default function CoachClient({ initialProfile }: { initialProfile: CoachProfile | null }) {
+  const [profile, setProfile] = useState<CoachProfile>(initialProfile ?? EMPTY_PROFILE)
+  const [newInfluence, setNewInfluence] = useState('')
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+  const [feedbackOpen, setFeedbackOpen] = useState(false)
+
+  function addInfluence() {
+    const name = newInfluence.trim()
+    if (!name || profile.influences.includes(name)) return
+    setProfile(p => ({ ...p, influences: [...p.influences, name] }))
+    setNewInfluence('')
+  }
+
+  function removeInfluence(name: string) {
+    setProfile(p => ({ ...p, influences: p.influences.filter(i => i !== name) }))
+  }
+
+  function handleSave() {
+    setSaved(false)
+    setError(null)
+    startTransition(async () => {
+      const result = await saveCoachProfile(profile)
+      if (result.success) {
+        setSaved(true)
+        setTimeout(() => setSaved(false), 3000)
+      } else {
+        setError(result.error ?? 'Something went wrong')
+      }
+    })
+  }
+
+  return (
+    <>
+      <div className="px-4 pt-6 pb-8 space-y-6">
+        <h1 className="text-xl font-bold text-gray-900">Coach</h1>
+
+        {/* Name */}
+        <div className="space-y-1">
+          <label className="text-sm font-medium text-gray-700">Name</label>
+          <input
+            type="text"
+            value={profile.name}
+            onChange={e => setProfile(p => ({ ...p, name: e.target.value }))}
+            placeholder="Your name"
+            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
+          />
+        </div>
+
+        {/* Philosophy */}
+        <div className="space-y-1">
+          <label className="text-sm font-medium text-gray-700">Your coaching philosophy</label>
+          <textarea
+            value={profile.philosophy}
+            onChange={e => setProfile(p => ({ ...p, philosophy: e.target.value }))}
+            placeholder="What do you believe about training?"
+            rows={5}
+            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none resize-none"
+          />
+        </div>
+
+        {/* Influences */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-gray-700">Coaching influences</label>
+          {profile.influences.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {profile.influences.map(name => (
+                <span
+                  key={name}
+                  className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700"
+                >
+                  {name}
+                  <button
+                    onClick={() => removeInfluence(name)}
+                    className="text-blue-400 hover:text-blue-600 ml-0.5"
+                    aria-label={`Remove ${name}`}
+                  >
+                    <X size={13} />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={newInfluence}
+              onChange={e => setNewInfluence(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && addInfluence()}
+              placeholder="e.g. Jack Daniels"
+              className="flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
+            />
+            <button
+              onClick={addInfluence}
+              disabled={!newInfluence.trim()}
+              className="flex items-center gap-1 rounded-lg bg-blue-600 px-3 py-2.5 text-sm font-medium text-white disabled:opacity-40"
+            >
+              <Plus size={15} />
+              Add
+            </button>
+          </div>
+        </div>
+
+        {/* Credentials */}
+        <div className="space-y-1">
+          <label className="text-sm font-medium text-gray-700">Credentials</label>
+          <input
+            type="text"
+            value={profile.credentials}
+            onChange={e => setProfile(p => ({ ...p, credentials: e.target.value }))}
+            placeholder="e.g. RRCA Level 1 Certified Running Coach"
+            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
+          />
+        </div>
+
+        {/* Save */}
+        <button
+          onClick={handleSave}
+          disabled={isPending}
+          className="w-full rounded-lg bg-blue-600 py-3 text-sm font-semibold text-white disabled:opacity-50 transition-colors"
+        >
+          {isPending ? 'Saving…' : saved ? 'Saved ✓' : 'Save Profile'}
+        </button>
+
+        {error && (
+          <p className="text-sm text-red-600 text-center">{error}</p>
+        )}
+
+        {/* Feedback */}
+        <div className="border-t border-gray-100 pt-4">
+          <button
+            onClick={() => setFeedbackOpen(true)}
+            className="flex items-center gap-2 text-sm text-gray-400 hover:text-gray-600"
+          >
+            <Flag size={15} />
+            Give feedback
+          </button>
+        </div>
+      </div>
+
+      <FeedbackDrawer open={feedbackOpen} onClose={() => setFeedbackOpen(false)} />
+    </>
+  )
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -162,3 +162,11 @@ export type WeekReview = {
   summary: string
   ptSummary: string
 }
+
+export type CoachProfile = {
+  name: string
+  philosophy: string
+  influences: string[]
+  credentials: string
+  updatedAt: string
+}

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -1,5 +1,5 @@
 import { kv } from '@vercel/kv'
-import type { CoachingNote, WeekReview, CheckIn } from './data'
+import type { CoachingNote, WeekReview, CheckIn, CoachProfile } from './data'
 
 export async function getCoachingNote(date: string): Promise<CoachingNote | null> {
   return kv.get<CoachingNote>(`coaching:${date}`)
@@ -31,4 +31,16 @@ export async function getWeekReview(weekNumber: number): Promise<WeekReview | nu
 
 export async function setWeekReview(review: WeekReview): Promise<void> {
   await kv.set(`week-review:${review.weekNumber}`, review, { ex: 60 * 60 * 24 * 14 })
+}
+
+export async function getCoachProfile(): Promise<CoachProfile | null> {
+  try {
+    return await kv.get<CoachProfile>('coach:profile')
+  } catch {
+    return null
+  }
+}
+
+export async function setCoachProfile(profile: CoachProfile): Promise<void> {
+  await kv.set('coach:profile', profile)
 }


### PR DESCRIPTION
## What

Adds the Coach tab (5th nav item) and a profile screen where the coach can declare their identity — the foundation of the Playbook epic (#40).

## Changes

- **Coach tab** in bottom nav (ClipboardList icon, rightmost). Active state highlights correctly for /coach and sub-routes.
- **Profile screen** with editable fields: name, philosophy (multi-line), coaching influences (add/remove chips), credentials.
- **Persists to Vercel KV** under coach:profile via new saveCoachProfile server action.
- **Feedback** moved from bottom nav into the Coach page (small link at the bottom), keeping the nav clean at 5 real tabs.
- New CoachProfile type in lib/data.ts, KV helpers in lib/kv.ts.

## Test on mobile

1. Tap the Coach tab (clipboard icon, far right)
2. Fill in name, philosophy, a couple of influences, credentials
3. Hit Save — should show "Saved" briefly
4. Navigate away and back — profile should persist
5. Feedback link at the bottom should open the feedback drawer

closes #41