### PR TITLE
Playbook tab and quote capture — story #42

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -3,8 +3,8 @@
 import { revalidatePath } from 'next/cache'
 import { fetchPlanData, fetchTrainingData, fetchTrainingLog } from '@/lib/sheets'
 import { generateCoachingNote, generateRestDayNote, generatePostWorkoutNote, generatePTSummaryForRange, generateWeekReview, sendCheckInMessage } from '@/lib/ai'
-import { getCoachingNote, setCoachingNote, getPostCoachingNote, setPostCoachingNote, getCheckIn, setCheckIn, getWeekReview, setWeekReview, setCoachProfile } from '@/lib/kv'
-import type { CoachingNote, WeekReview, CheckInMessage, CoachProfile } from '@/lib/data'
+import { getCoachingNote, setCoachingNote, getPostCoachingNote, setPostCoachingNote, getCheckIn, setCheckIn, getWeekReview, setWeekReview, setCoachProfile, getPlaybookQuotes, savePlaybookQuotes } from '@/lib/kv'
+import type { CoachingNote, WeekReview, CheckInMessage, CoachProfile, PlaybookQuote } from '@/lib/data'
 
 export async function fetchCoachingNoteForDate(date: string): Promise<CoachingNote | null> {
   try {
@@ -586,5 +586,30 @@ export async function saveCoachProfile(profile: CoachProfile): Promise<{ success
     return { success: true }
   } catch (e) {
     return { success: false, error: e instanceof Error ? e.message : 'Failed to save profile' }
+  }
+}
+
+export async function addPlaybookQuote(quote: Omit<PlaybookQuote, 'id' | 'createdAt'>): Promise<{ success: boolean; quote?: PlaybookQuote; error?: string }> {
+  try {
+    const quotes = await getPlaybookQuotes()
+    const newQuote: PlaybookQuote = {
+      ...quote,
+      id: crypto.randomUUID(),
+      createdAt: new Date().toISOString(),
+    }
+    await savePlaybookQuotes([newQuote, ...quotes])
+    return { success: true, quote: newQuote }
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Failed to save quote' }
+  }
+}
+
+export async function removePlaybookQuote(id: string): Promise<{ success: boolean; error?: string }> {
+  try {
+    const quotes = await getPlaybookQuotes()
+    await savePlaybookQuotes(quotes.filter(q => q.id !== id))
+    return { success: true }
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Failed to delete quote' }
   }
 }

--- a/app/coach/page.tsx
+++ b/app/coach/page.tsx
@@ -1,7 +1,7 @@
-import { getCoachProfile } from '@/lib/kv'
+import { getCoachProfile, getPlaybookQuotes } from '@/lib/kv'
 import CoachClient from '@/components/CoachClient'
 
 export default async function CoachPage() {
-  const profile = await getCoachProfile()
-  return <CoachClient initialProfile={profile} />
+  const [profile, quotes] = await Promise.all([getCoachProfile(), getPlaybookQuotes()])
+  return <CoachClient initialProfile={profile} initialQuotes={quotes} />
 }

--- a/components/CoachClient.tsx
+++ b/components/CoachClient.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import { Flag, X, Plus } from 'lucide-react'
-import type { CoachProfile } from '@/lib/data'
-import { saveCoachProfile } from '@/app/actions'
+import { Flag, X, Plus, Trash2 } from 'lucide-react'
+import type { CoachProfile, PlaybookQuote } from '@/lib/data'
+import { saveCoachProfile, removePlaybookQuote } from '@/app/actions'
 import FeedbackDrawer from './FeedbackDrawer'
+import PlaybookQuoteDrawer from './PlaybookQuoteDrawer'
 
 const EMPTY_PROFILE: CoachProfile = {
   name: '',
@@ -14,13 +15,24 @@ const EMPTY_PROFILE: CoachProfile = {
   updatedAt: '',
 }
 
-export default function CoachClient({ initialProfile }: { initialProfile: CoachProfile | null }) {
+type Tab = 'profile' | 'playbook'
+
+type Props = {
+  initialProfile: CoachProfile | null
+  initialQuotes: PlaybookQuote[]
+}
+
+export default function CoachClient({ initialProfile, initialQuotes }: Props) {
+  const [activeTab, setActiveTab] = useState<Tab>('profile')
   const [profile, setProfile] = useState<CoachProfile>(initialProfile ?? EMPTY_PROFILE)
   const [newInfluence, setNewInfluence] = useState('')
   const [saved, setSaved] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
   const [feedbackOpen, setFeedbackOpen] = useState(false)
+  const [quoteDrawerOpen, setQuoteDrawerOpen] = useState(false)
+  const [quotes, setQuotes] = useState<PlaybookQuote[]>(initialQuotes)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
 
   function addInfluence() {
     const name = newInfluence.trim()
@@ -35,125 +47,217 @@ export default function CoachClient({ initialProfile }: { initialProfile: CoachP
 
   function handleSave() {
     setSaved(false)
-    setError(null)
+    setSaveError(null)
     startTransition(async () => {
       const result = await saveCoachProfile(profile)
       if (result.success) {
         setSaved(true)
         setTimeout(() => setSaved(false), 3000)
       } else {
-        setError(result.error ?? 'Something went wrong')
+        setSaveError(result.error ?? 'Something went wrong')
       }
+    })
+  }
+
+  function handleQuoteSaved(quote: PlaybookQuote) {
+    setQuotes(q => [quote, ...q])
+  }
+
+  function handleDeleteQuote(id: string) {
+    setDeletingId(id)
+    startTransition(async () => {
+      const result = await removePlaybookQuote(id)
+      if (result.success) {
+        setQuotes(q => q.filter(quote => quote.id !== id))
+      }
+      setDeletingId(null)
     })
   }
 
   return (
     <>
-      <div className="px-4 pt-6 pb-8 space-y-6">
-        <h1 className="text-xl font-bold text-gray-900">Coach</h1>
+      <div className="px-4 pt-6 pb-8">
+        <h1 className="text-xl font-bold text-gray-900 mb-4">Coach</h1>
 
-        {/* Name */}
-        <div className="space-y-1">
-          <label className="text-sm font-medium text-gray-700">Name</label>
-          <input
-            type="text"
-            value={profile.name}
-            onChange={e => setProfile(p => ({ ...p, name: e.target.value }))}
-            placeholder="Your name"
-            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
-          />
-        </div>
-
-        {/* Philosophy */}
-        <div className="space-y-1">
-          <label className="text-sm font-medium text-gray-700">Your coaching philosophy</label>
-          <textarea
-            value={profile.philosophy}
-            onChange={e => setProfile(p => ({ ...p, philosophy: e.target.value }))}
-            placeholder="What do you believe about training?"
-            rows={5}
-            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none resize-none"
-          />
-        </div>
-
-        {/* Influences */}
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-gray-700">Coaching influences</label>
-          {profile.influences.length > 0 && (
-            <div className="flex flex-wrap gap-2">
-              {profile.influences.map(name => (
-                <span
-                  key={name}
-                  className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700"
-                >
-                  {name}
-                  <button
-                    onClick={() => removeInfluence(name)}
-                    className="text-blue-400 hover:text-blue-600 ml-0.5"
-                    aria-label={`Remove ${name}`}
-                  >
-                    <X size={13} />
-                  </button>
-                </span>
-              ))}
-            </div>
-          )}
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={newInfluence}
-              onChange={e => setNewInfluence(e.target.value)}
-              onKeyDown={e => e.key === 'Enter' && addInfluence()}
-              placeholder="e.g. Jack Daniels"
-              className="flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
-            />
+        {/* Tabs */}
+        <div className="flex border-b border-gray-200 mb-6">
+          {(['profile', 'playbook'] as Tab[]).map(tab => (
             <button
-              onClick={addInfluence}
-              disabled={!newInfluence.trim()}
-              className="flex items-center gap-1 rounded-lg bg-blue-600 px-3 py-2.5 text-sm font-medium text-white disabled:opacity-40"
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`flex-1 pb-2.5 text-sm font-medium capitalize transition-colors border-b-2 -mb-px ${
+                activeTab === tab
+                  ? 'border-blue-600 text-blue-600'
+                  : 'border-transparent text-gray-400 hover:text-gray-600'
+              }`}
             >
-              <Plus size={15} />
-              Add
+              {tab}
             </button>
+          ))}
+        </div>
+
+        {/* Profile tab */}
+        {activeTab === 'profile' && (
+          <div className="space-y-6">
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-gray-700">Name</label>
+              <input
+                type="text"
+                value={profile.name}
+                onChange={e => setProfile(p => ({ ...p, name: e.target.value }))}
+                placeholder="Your name"
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
+              />
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-gray-700">Your coaching philosophy</label>
+              <textarea
+                value={profile.philosophy}
+                onChange={e => setProfile(p => ({ ...p, philosophy: e.target.value }))}
+                placeholder="What do you believe about training?"
+                rows={5}
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none resize-none"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-gray-700">Coaching influences</label>
+              {profile.influences.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {profile.influences.map(name => (
+                    <span
+                      key={name}
+                      className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700"
+                    >
+                      {name}
+                      <button
+                        onClick={() => removeInfluence(name)}
+                        className="text-blue-400 hover:text-blue-600 ml-0.5"
+                        aria-label={`Remove ${name}`}
+                      >
+                        <X size={13} />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={newInfluence}
+                  onChange={e => setNewInfluence(e.target.value)}
+                  onKeyDown={e => e.key === 'Enter' && addInfluence()}
+                  placeholder="e.g. Jack Daniels"
+                  className="flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
+                />
+                <button
+                  onClick={addInfluence}
+                  disabled={!newInfluence.trim()}
+                  className="flex items-center gap-1 rounded-lg bg-blue-600 px-3 py-2.5 text-sm font-medium text-white disabled:opacity-40"
+                >
+                  <Plus size={15} />
+                  Add
+                </button>
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-gray-700">Credentials</label>
+              <input
+                type="text"
+                value={profile.credentials}
+                onChange={e => setProfile(p => ({ ...p, credentials: e.target.value }))}
+                placeholder="e.g. RRCA Level 1 Certified Running Coach"
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
+              />
+            </div>
+
+            <button
+              onClick={handleSave}
+              disabled={isPending}
+              className="w-full rounded-lg bg-blue-600 py-3 text-sm font-semibold text-white disabled:opacity-50 transition-colors"
+            >
+              {isPending ? 'Saving…' : saved ? 'Saved ✓' : 'Save Profile'}
+            </button>
+
+            {saveError && <p className="text-sm text-red-600 text-center">{saveError}</p>}
+
+            <div className="border-t border-gray-100 pt-4">
+              <button
+                onClick={() => setFeedbackOpen(true)}
+                className="flex items-center gap-2 text-sm text-gray-400 hover:text-gray-600"
+              >
+                <Flag size={15} />
+                Give feedback
+              </button>
+            </div>
           </div>
-        </div>
-
-        {/* Credentials */}
-        <div className="space-y-1">
-          <label className="text-sm font-medium text-gray-700">Credentials</label>
-          <input
-            type="text"
-            value={profile.credentials}
-            onChange={e => setProfile(p => ({ ...p, credentials: e.target.value }))}
-            placeholder="e.g. RRCA Level 1 Certified Running Coach"
-            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
-          />
-        </div>
-
-        {/* Save */}
-        <button
-          onClick={handleSave}
-          disabled={isPending}
-          className="w-full rounded-lg bg-blue-600 py-3 text-sm font-semibold text-white disabled:opacity-50 transition-colors"
-        >
-          {isPending ? 'Saving…' : saved ? 'Saved ✓' : 'Save Profile'}
-        </button>
-
-        {error && (
-          <p className="text-sm text-red-600 text-center">{error}</p>
         )}
 
-        {/* Feedback */}
-        <div className="border-t border-gray-100 pt-4">
-          <button
-            onClick={() => setFeedbackOpen(true)}
-            className="flex items-center gap-2 text-sm text-gray-400 hover:text-gray-600"
-          >
-            <Flag size={15} />
-            Give feedback
-          </button>
-        </div>
+        {/* Playbook tab */}
+        {activeTab === 'playbook' && (
+          <div className="space-y-4">
+            <button
+              onClick={() => setQuoteDrawerOpen(true)}
+              className="w-full rounded-lg border-2 border-dashed border-gray-200 py-3 text-sm font-medium text-gray-400 hover:border-blue-300 hover:text-blue-500 transition-colors"
+            >
+              + Add Quote
+            </button>
+
+            {quotes.length === 0 ? (
+              <p className="text-center text-sm text-gray-400 py-10">
+                Your Playbook is empty. Add the first quote that shaped how you coach.
+              </p>
+            ) : (
+              <div className="space-y-4">
+                {quotes.map(q => (
+                  <div key={q.id} className="rounded-xl bg-white border border-gray-100 p-4 shadow-sm space-y-2">
+                    <p className="text-sm text-gray-800 italic leading-relaxed">
+                      &ldquo;{q.quote}&rdquo;
+                    </p>
+                    <p className="text-xs text-gray-500 font-medium">
+                      {q.author}; {q.source}
+                    </p>
+                    {q.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-1.5">
+                        {q.tags.map(tag => (
+                          <span
+                            key={tag}
+                            className="rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-600"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    {q.note && (
+                      <p className="text-xs text-gray-400 border-t border-gray-50 pt-2">{q.note}</p>
+                    )}
+                    <div className="flex justify-end pt-1">
+                      <button
+                        onClick={() => handleDeleteQuote(q.id)}
+                        disabled={deletingId === q.id}
+                        className="text-gray-300 hover:text-red-400 transition-colors disabled:opacity-40"
+                        aria-label="Delete quote"
+                      >
+                        <Trash2 size={15} />
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </div>
+
+      {quoteDrawerOpen && (
+        <PlaybookQuoteDrawer
+          onClose={() => setQuoteDrawerOpen(false)}
+          onSaved={handleQuoteSaved}
+        />
+      )}
 
       <FeedbackDrawer open={feedbackOpen} onClose={() => setFeedbackOpen(false)} />
     </>

--- a/components/PlaybookQuoteDrawer.tsx
+++ b/components/PlaybookQuoteDrawer.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { X } from 'lucide-react'
+import { PLAYBOOK_TAGS, type PlaybookQuote, type PlaybookTag } from '@/lib/data'
+import { addPlaybookQuote } from '@/app/actions'
+
+type Props = {
+  onClose: () => void
+  onSaved: (quote: PlaybookQuote) => void
+}
+
+const EMPTY = { quote: '', author: '', source: '', tags: [] as PlaybookTag[], note: '' }
+
+export default function PlaybookQuoteDrawer({ onClose, onSaved }: Props) {
+  const [form, setForm] = useState(EMPTY)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function toggleTag(tag: PlaybookTag) {
+    setForm(f => ({
+      ...f,
+      tags: f.tags.includes(tag) ? f.tags.filter(t => t !== tag) : [...f.tags, tag],
+    }))
+  }
+
+  function canSave() {
+    return form.quote.trim() && form.author.trim() && form.source.trim()
+  }
+
+  function handleSave() {
+    if (!canSave()) return
+    setError(null)
+    startTransition(async () => {
+      const result = await addPlaybookQuote(form)
+      if (result.success && result.quote) {
+        onSaved(result.quote)
+        onClose()
+      } else {
+        setError(result.error ?? 'Something went wrong')
+      }
+    })
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col justify-end">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative bg-white rounded-t-3xl px-4 pt-3 pb-10 shadow-xl max-h-[92vh] overflow-y-auto">
+        <div className="w-10 h-1 bg-gray-200 rounded-full mx-auto mb-4" />
+
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="text-lg font-bold text-gray-900">Add to Playbook</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          {/* Quote */}
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">Quote</label>
+            <textarea
+              value={form.quote}
+              onChange={e => setForm(f => ({ ...f, quote: e.target.value }))}
+              placeholder="Paste or type the quote..."
+              rows={4}
+              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none resize-none"
+            />
+          </div>
+
+          {/* Author */}
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">Author</label>
+            <input
+              type="text"
+              value={form.author}
+              onChange={e => setForm(f => ({ ...f, author: e.target.value }))}
+              placeholder="e.g. Jack Daniels"
+              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+
+          {/* Source */}
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">Source</label>
+            <input
+              type="text"
+              value={form.source}
+              onChange={e => setForm(f => ({ ...f, source: e.target.value }))}
+              placeholder="e.g. Daniels Running Formula, 3rd Ed."
+              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+
+          {/* Tags */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700">Topic tags</label>
+            <div className="flex flex-wrap gap-2">
+              {PLAYBOOK_TAGS.map(tag => {
+                const selected = form.tags.includes(tag)
+                return (
+                  <button
+                    key={tag}
+                    onClick={() => toggleTag(tag)}
+                    className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                      selected
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                    }`}
+                  >
+                    {tag}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* Note */}
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">Your note</label>
+            <textarea
+              value={form.note}
+              onChange={e => setForm(f => ({ ...f, note: e.target.value }))}
+              placeholder="Why does this belong in your Playbook? What does it change about how you coach?"
+              rows={3}
+              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none resize-none"
+            />
+          </div>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <button
+            onClick={handleSave}
+            disabled={!canSave() || isPending}
+            className="w-full rounded-lg bg-blue-600 py-3 text-sm font-semibold text-white disabled:opacity-40 transition-colors"
+          >
+            {isPending ? 'Saving…' : 'Save Quote'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -170,3 +170,20 @@ export type CoachProfile = {
   credentials: string
   updatedAt: string
 }
+
+export const PLAYBOOK_TAGS = [
+  'Pacing', 'Threshold', 'Easy Running', 'Long Run', 'Recovery',
+  'Periodization', 'Race Prep', 'Mental', 'Strength', 'Nutrition',
+] as const
+
+export type PlaybookTag = typeof PLAYBOOK_TAGS[number]
+
+export type PlaybookQuote = {
+  id: string
+  quote: string
+  author: string
+  source: string
+  tags: PlaybookTag[]
+  note: string
+  createdAt: string
+}

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -1,5 +1,5 @@
 import { kv } from '@vercel/kv'
-import type { CoachingNote, WeekReview, CheckIn, CoachProfile } from './data'
+import type { CoachingNote, WeekReview, CheckIn, CoachProfile, PlaybookQuote } from './data'
 
 export async function getCoachingNote(date: string): Promise<CoachingNote | null> {
   return kv.get<CoachingNote>(`coaching:${date}`)
@@ -43,4 +43,16 @@ export async function getCoachProfile(): Promise<CoachProfile | null> {
 
 export async function setCoachProfile(profile: CoachProfile): Promise<void> {
   await kv.set('coach:profile', profile)
+}
+
+export async function getPlaybookQuotes(): Promise<PlaybookQuote[]> {
+  try {
+    return await kv.get<PlaybookQuote[]>('coach:playbook:quotes') ?? []
+  } catch {
+    return []
+  }
+}
+
+export async function savePlaybookQuotes(quotes: PlaybookQuote[]): Promise<void> {
+  await kv.set('coach:playbook:quotes', quotes)
 }


### PR DESCRIPTION
## What

Adds the Playbook tab to the Coach section — the core of epic #40. Coaches can now capture quotes from any source, tag them by topic, and add a personal note explaining why the quote belongs in their Playbook.

## Changes

- **Playbook tab** alongside Profile in the Coach section
- **PlaybookQuoteDrawer** — bottom sheet form with: quote text, author, source, topic tags (tap to toggle), and a personal note field with a prompting placeholder
- **Quote list** — each quote displays in a library card style: quote in italics, author/source attribution, topic tag chips, personal note, delete button
- **Empty state** — "Your Playbook is empty. Add the first quote that shaped how you coach."
- **KV storage** — quotes persist under `coach:playbook:quotes` as a JSON array, newest first
- New `PlaybookQuote` type and `PLAYBOOK_TAGS` constant in `lib/data.ts`

## Test on mobile

1. Tap Coach tab; tap Playbook
2. Empty state should show
3. Tap Add Quote; fill in a quote, author, source; tap some tags; add a note
4. Save — quote should appear in the list immediately
5. Navigate away and back — quote persists
6. Tap the trash icon — quote is removed

closes #42
