### PR TITLE
Photo quote capture — story #46

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -613,3 +613,39 @@ export async function removePlaybookQuote(id: string): Promise<{ success: boolea
     return { success: false, error: e instanceof Error ? e.message : 'Failed to delete quote' }
   }
 }
+
+export async function extractQuoteFromImage(
+  base64Image: string,
+  mimeType: string,
+): Promise<{ text?: string; error?: string }> {
+  try {
+    const Anthropic = (await import('@anthropic-ai/sdk')).default
+    const client = new Anthropic()
+    const message = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 500,
+      messages: [{
+        role: 'user',
+        content: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: mimeType as 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif',
+              data: base64Image,
+            },
+          },
+          {
+            type: 'text',
+            text: 'This is a photograph of a printed page from a coaching or training book. Extract the most meaningful and complete passage visible — the kind a coach would want to quote verbatim. Return only the exact text of that passage, nothing else. No commentary, no introduction, no punctuation changes. Just the verbatim text.',
+          },
+        ],
+      }],
+    })
+    const text = message.content[0].type === 'text' ? message.content[0].text.trim() : ''
+    if (!text) return { error: 'No text found in photo' }
+    return { text }
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'Failed to extract text from photo' }
+  }
+}

--- a/components/PlaybookQuoteDrawer.tsx
+++ b/components/PlaybookQuoteDrawer.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useState, useTransition } from 'react'
-import { X } from 'lucide-react'
+import { useState, useTransition, useRef } from 'react'
+import { X, Camera } from 'lucide-react'
 import { PLAYBOOK_TAGS, type PlaybookQuote, type PlaybookTag } from '@/lib/data'
-import { addPlaybookQuote } from '@/app/actions'
+import { addPlaybookQuote, extractQuoteFromImage } from '@/app/actions'
 
 type Props = {
   onClose: () => void
@@ -12,10 +12,31 @@ type Props = {
 
 const EMPTY = { quote: '', author: '', source: '', tags: [] as PlaybookTag[], note: '' }
 
+async function resizeImage(file: File, maxPx = 1200): Promise<{ base64: string; mimeType: string }> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    const url = URL.createObjectURL(file)
+    img.onload = () => {
+      URL.revokeObjectURL(url)
+      const scale = Math.min(1, maxPx / Math.max(img.width, img.height))
+      const canvas = document.createElement('canvas')
+      canvas.width = Math.round(img.width * scale)
+      canvas.height = Math.round(img.height * scale)
+      canvas.getContext('2d')!.drawImage(img, 0, 0, canvas.width, canvas.height)
+      const dataUrl = canvas.toDataURL('image/jpeg', 0.85)
+      resolve({ base64: dataUrl.split(',')[1], mimeType: 'image/jpeg' })
+    }
+    img.onerror = reject
+    img.src = url
+  })
+}
+
 export default function PlaybookQuoteDrawer({ onClose, onSaved }: Props) {
   const [form, setForm] = useState(EMPTY)
   const [error, setError] = useState<string | null>(null)
+  const [extracting, setExtracting] = useState(false)
   const [isPending, startTransition] = useTransition()
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   function toggleTag(tag: PlaybookTag) {
     setForm(f => ({
@@ -26,6 +47,27 @@ export default function PlaybookQuoteDrawer({ onClose, onSaved }: Props) {
 
   function canSave() {
     return form.quote.trim() && form.author.trim() && form.source.trim()
+  }
+
+  async function handlePhoto(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setError(null)
+    setExtracting(true)
+    try {
+      const { base64, mimeType } = await resizeImage(file)
+      const result = await extractQuoteFromImage(base64, mimeType)
+      if (result.text) {
+        setForm(f => ({ ...f, quote: result.text! }))
+      } else {
+        setError(result.error ?? 'Could not extract text — try typing it manually')
+      }
+    } catch {
+      setError('Could not read photo — try typing the quote manually')
+    } finally {
+      setExtracting(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
   }
 
   function handleSave() {
@@ -58,13 +100,32 @@ export default function PlaybookQuoteDrawer({ onClose, onSaved }: Props) {
         <div className="space-y-4">
           {/* Quote */}
           <div className="space-y-1">
-            <label className="text-sm font-medium text-gray-700">Quote</label>
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium text-gray-700">Quote</label>
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                disabled={extracting}
+                className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 disabled:opacity-40"
+              >
+                <Camera size={14} />
+                {extracting ? 'Reading photo…' : 'From photo'}
+              </button>
+            </div>
             <textarea
               value={form.quote}
               onChange={e => setForm(f => ({ ...f, quote: e.target.value }))}
-              placeholder="Paste or type the quote..."
+              placeholder={extracting ? 'Reading your photo…' : 'Paste or type the quote...'}
               rows={4}
-              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none resize-none"
+              disabled={extracting}
+              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none resize-none disabled:bg-gray-50"
+            />
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              capture="environment"
+              className="hidden"
+              onChange={handlePhoto}
             />
           </div>
 
@@ -131,7 +192,7 @@ export default function PlaybookQuoteDrawer({ onClose, onSaved }: Props) {
 
           <button
             onClick={handleSave}
-            disabled={!canSave() || isPending}
+            disabled={!canSave() || isPending || extracting}
             className="w-full rounded-lg bg-blue-600 py-3 text-sm font-semibold text-white disabled:opacity-40 transition-colors"
           >
             {isPending ? 'Saving…' : 'Save Quote'}

--- a/components/TodayClient.tsx
+++ b/components/TodayClient.tsx
@@ -507,6 +507,248 @@ export default function TodayClient({
         </div>
       )}
 
+      {isRestDay ? (
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden mb-4">
+          <div className="p-5">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <div className="text-xs font-bold text-gray-400 tracking-wide mb-1">
+                  {isViewingToday ? 'TODAY' : 'THIS DAY'} · REST
+                </div>
+                <div className="text-xl font-bold text-gray-900">Recovery Day</div>
+                {viewPhase && (
+                  <div className="text-sm text-gray-500 mt-0.5">{viewPhase.name}</div>
+                )}
+              </div>
+              <span className="text-xs font-semibold px-2.5 py-1 rounded-full bg-gray-100 text-gray-500 shrink-0">Rest</span>
+            </div>
+            {note?.verdict && (
+              <p className="text-sm text-gray-600 mt-3 leading-relaxed">{note.verdict}</p>
+            )}
+          </div>
+          {tomorrowWorkout && (
+            <div className="border-t border-gray-100 px-5 py-3 bg-gray-50">
+              <div className="text-xs font-bold text-gray-400 tracking-wide mb-1.5">TOMORROW</div>
+              <div className="flex items-center justify-between gap-2">
+                <div>
+                  <div className="text-sm font-semibold text-gray-800">
+                    {tomorrowWorkout.workout ?? tomorrowWorkout.runType ?? tomorrowWorkout.dayType}
+                  </div>
+                  {(tomorrowWorkout.distance || tomorrowWorkout.targetPace || tomorrowWorkout.hrZone) && (
+                    <div className="text-xs text-gray-500 mt-0.5">
+                      {[
+                        tomorrowWorkout.distance && `${tomorrowWorkout.distance} mi`,
+                        tomorrowWorkout.targetPace && `${tomorrowWorkout.targetPace} /mi`,
+                        tomorrowWorkout.hrZone && `Z${tomorrowWorkout.hrZone}`,
+                      ].filter(Boolean).join(' · ')}
+                    </div>
+                  )}
+                </div>
+                <span className="text-xs font-semibold px-2.5 py-1 rounded-full bg-white border border-gray-200 text-gray-600 shrink-0 whitespace-nowrap">
+                  {tomorrowWorkout.runType ?? tomorrowWorkout.dayType}
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+      ) : displayEntry ? (
+        isPostRun ? (
+          <div className={`bg-white rounded-2xl border border-gray-100 border-l-4 ${runTypeBorderColor(displayEntry)} shadow-sm overflow-hidden mb-4`}>
+            <div className="p-5">
+              <div className="text-xs font-bold text-gray-400 tracking-wide mb-1">DONE</div>
+              <div className="text-xl font-bold text-gray-900 mb-3">
+                {displayEntry.workout ?? displayEntry.runType ?? displayEntry.dayType}
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-start gap-3">
+                  <span className="text-xs font-semibold text-gray-400 w-14 shrink-0 pt-0.5">Planned</span>
+                  <span className="text-sm text-gray-500">
+                    {[
+                      displayEntry.distance && `${displayEntry.distance} mi`,
+                      displayEntry.targetPace && `${displayEntry.targetPace} /mi`,
+                      displayEntry.hrZone && `Z${displayEntry.hrZone}`,
+                      viewPhase?.name,
+                    ].filter(Boolean).join(' · ')}
+                  </span>
+                </div>
+                {runLog && (
+                  <div className="flex items-start gap-3">
+                    <span className="text-xs font-semibold text-gray-400 w-14 shrink-0 pt-0.5">Actual</span>
+                    <div className="text-sm font-semibold text-gray-900">
+                      {[
+                        runLog.distance && `${runLog.distance} mi`,
+                        runLog.pace && `${runLog.pace} /mi`,
+                        runLog.duration && `${runLog.duration} min`,
+                        runLog.avgHr && `${runLog.avgHr} bpm`,
+                      ].filter(Boolean).join(' · ')}
+                      {distanceDelta != null && Math.abs(distanceDelta) > 0.5 && (
+                        <span className={`ml-2 text-xs font-normal ${distanceDelta > 0 ? 'text-emerald-600' : 'text-amber-600'}`}>
+                          ({distanceDelta > 0 ? '+' : ''}{distanceDelta.toFixed(1)} mi)
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+            {/* Signal — embedded at bottom, hidden until tapped */}
+            <div className="border-t border-gray-100">
+              <button
+                onClick={() => setPostWorkoutExpanded(v => !v)}
+                className="w-full px-5 py-3 flex items-center justify-between text-left bg-gray-50 touch-manipulation"
+              >
+                <div className="flex items-center gap-2">
+                  <Radio size={13} className="text-emerald-600" />
+                  <span className="text-xs font-bold text-emerald-700 tracking-wide">The Signal</span>
+                  <span className="text-xs text-emerald-500">Asst. Coach</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span onClick={e => { e.stopPropagation(); handleGeneratePostNote() }}>
+                    <RefreshCw size={12} className={`text-emerald-400 hover:text-emerald-600 ${postNoteLoading ? 'animate-spin' : ''}`} />
+                  </span>
+                  {postWorkoutExpanded ? <ChevronUp size={14} className="text-gray-400" /> : <ChevronDown size={14} className="text-gray-400" />}
+                </div>
+              </button>
+              {postWorkoutExpanded && (
+                <div className="px-5 pb-5 pt-3 bg-emerald-50">
+                  {postNoteLoading ? (
+                    <p className="text-sm text-gray-400 italic">Generating...</p>
+                  ) : postNote ? (
+                    <>
+                      {postNote.verdict && (
+                        <p className="text-sm text-emerald-900 leading-snug mb-3">{postNote.verdict.replace(/\*+/g, '')}</p>
+                      )}
+                      <div className="prose prose-sm prose-slate max-w-none">
+                        <ReactMarkdown>{postNote.coachingTake}</ReactMarkdown>
+                      </div>
+                    </>
+                  ) : (
+                    <p className="text-sm text-gray-400 italic">Tap ↻ to generate analysis.</p>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className={`bg-white rounded-2xl border border-gray-100 border-l-4 ${runTypeBorderColor(displayEntry)} shadow-sm overflow-hidden mb-4`}>
+            <div className="p-5">
+              <div className="flex items-start justify-between gap-2 mb-2">
+                <div>
+                  <div className="text-xs font-bold text-gray-400 tracking-wide mb-1">
+                    {displayEntry.date === viewDate
+                      ? (isViewingToday ? 'TODAY' : 'THIS DAY')
+                      : `NEXT UP · ${new Date(displayEntry.date + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}`}
+                  </div>
+                  <div className="text-xl font-bold text-gray-900">
+                    {displayEntry.workout ?? displayEntry.runType ?? displayEntry.dayType}
+                  </div>
+                </div>
+                <div className="flex flex-col items-end gap-1.5 shrink-0">
+                  {effectiveLeaveBy && displayEntry.date === viewDate && (
+                    editingLeaveBy ? (
+                      <input
+                        type="time"
+                        defaultValue={runStartOverride ?? defaultRunStart ?? '06:30'}
+                        autoFocus
+                        className="text-xs border border-amber-200 rounded-lg px-2 py-1 bg-amber-50 text-amber-700 w-24"
+                        onBlur={e => {
+                          const val = e.target.value
+                          if (val) {
+                            setRunStartOverride(val)
+                            localStorage.setItem(`trainer-run-start-${today}`, val)
+                          }
+                          setEditingLeaveBy(false)
+                        }}
+                        onKeyDown={e => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
+                      />
+                    ) : (
+                      <button
+                        onClick={() => setEditingLeaveBy(true)}
+                        className="flex items-center gap-1 text-xs font-semibold text-amber-700 bg-amber-50 border border-amber-100 px-2 py-1 rounded-lg"
+                      >
+                        <Clock size={11} />
+                        Leave by {effectiveLeaveBy}
+                      </button>
+                    )
+                  )}
+                  <span className="text-xs font-semibold px-2.5 py-1 rounded-full bg-gray-100 text-gray-600 whitespace-nowrap">
+                    {displayEntry.runType ?? displayEntry.dayType}
+                  </span>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-3 text-sm text-gray-500 mb-3">
+                {displayEntry.distance && <span className="font-semibold text-gray-700">{displayEntry.distance} mi</span>}
+                {displayEntry.hrZone && <span>Zone {displayEntry.hrZone}</span>}
+                {displayEntry.targetPace && <span>{displayEntry.targetPace} /mi</span>}
+                {viewPhase && <span>{viewPhase.name}</span>}
+              </div>
+              {workoutInstructions && (() => {
+                const firstLine = workoutInstructions.split(/\n|\.(?:\s|$)/)[0].trim()
+                const hasMore = workoutInstructions.length > firstLine.length + 1
+                return (
+                  <div className="mb-3">
+                    <div className="text-sm text-gray-800 leading-relaxed font-mono">
+                      {instructionsExpanded ? workoutInstructions : firstLine}
+                    </div>
+                    {hasMore && (
+                      <button
+                        onClick={() => setInstructionsExpanded(v => !v)}
+                        className="mt-1 text-xs text-blue-500 hover:text-blue-700 flex items-center gap-0.5"
+                      >
+                        {instructionsExpanded ? <><ChevronUp size={12} /> Less</> : <><ChevronDown size={12} /> Full workout</>}
+                      </button>
+                    )}
+                  </div>
+                )
+              })()}
+              {workoutReason && (
+                <button
+                  onClick={() => setReasonExpanded(v => !v)}
+                  className="text-xs text-gray-400 hover:text-gray-600 flex items-center gap-1 mb-3"
+                >
+                  <span>Why this workout</span>
+                  <span>{reasonExpanded ? '▴' : '▾'}</span>
+                </button>
+              )}
+              {workoutReason && reasonExpanded && (
+                <div className="text-sm text-gray-500 leading-relaxed mb-3 pl-2 border-l-2 border-gray-100">
+                  {workoutReason}
+                </div>
+              )}
+            </div>
+            {showSyncPrompt && (
+              <div className="border-t border-amber-100 bg-amber-50 px-5 py-3">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs text-amber-700">After 1pm — did you run this morning?</span>
+                  <button
+                    onClick={handleSync}
+                    disabled={syncing}
+                    className="flex items-center gap-1.5 text-xs font-semibold text-amber-700 hover:text-amber-900 disabled:opacity-40"
+                  >
+                    <RefreshCw size={11} className={syncing ? 'animate-spin' : ''} />
+                    {syncing ? 'Syncing…' : 'Sync Strava'}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )
+      ) : (
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5 mb-4">
+          <div className="text-sm text-gray-400 italic">No workout scheduled.</div>
+        </div>
+      )}
+
+      {displayEntry && displayEntry.notes && displayEntry.date === viewDate && (
+        <div className="bg-indigo-50 border border-indigo-100 rounded-2xl p-4 mb-4">
+          <div className="flex items-center gap-2 mb-2">
+            <Smile size={14} className="text-indigo-400" />
+            <div className="text-xs font-bold text-indigo-500 tracking-wide">Coach FouLox</div>
+          </div>
+          <p className="text-sm text-indigo-900 leading-relaxed">{displayEntry.notes}</p>
+        </div>
+      )}
+
       {/* Morning directive — shown after check-in completes (#9) */}
       {isMorningWindow && morningFeel && (
         <div className="mb-4 bg-blue-50 border border-blue-100 rounded-2xl px-4 py-3">
@@ -792,248 +1034,6 @@ export default function TodayClient({
               )
             })}
           </div>
-        </div>
-      )}
-
-      {isRestDay ? (
-        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden mb-4">
-          <div className="p-5">
-            <div className="flex items-start justify-between gap-2">
-              <div>
-                <div className="text-xs font-bold text-gray-400 tracking-wide mb-1">
-                  {isViewingToday ? 'TODAY' : 'THIS DAY'} · REST
-                </div>
-                <div className="text-xl font-bold text-gray-900">Recovery Day</div>
-                {viewPhase && (
-                  <div className="text-sm text-gray-500 mt-0.5">{viewPhase.name}</div>
-                )}
-              </div>
-              <span className="text-xs font-semibold px-2.5 py-1 rounded-full bg-gray-100 text-gray-500 shrink-0">Rest</span>
-            </div>
-            {note?.verdict && (
-              <p className="text-sm text-gray-600 mt-3 leading-relaxed">{note.verdict}</p>
-            )}
-          </div>
-          {tomorrowWorkout && (
-            <div className="border-t border-gray-100 px-5 py-3 bg-gray-50">
-              <div className="text-xs font-bold text-gray-400 tracking-wide mb-1.5">TOMORROW</div>
-              <div className="flex items-center justify-between gap-2">
-                <div>
-                  <div className="text-sm font-semibold text-gray-800">
-                    {tomorrowWorkout.workout ?? tomorrowWorkout.runType ?? tomorrowWorkout.dayType}
-                  </div>
-                  {(tomorrowWorkout.distance || tomorrowWorkout.targetPace || tomorrowWorkout.hrZone) && (
-                    <div className="text-xs text-gray-500 mt-0.5">
-                      {[
-                        tomorrowWorkout.distance && `${tomorrowWorkout.distance} mi`,
-                        tomorrowWorkout.targetPace && `${tomorrowWorkout.targetPace} /mi`,
-                        tomorrowWorkout.hrZone && `Z${tomorrowWorkout.hrZone}`,
-                      ].filter(Boolean).join(' · ')}
-                    </div>
-                  )}
-                </div>
-                <span className="text-xs font-semibold px-2.5 py-1 rounded-full bg-white border border-gray-200 text-gray-600 shrink-0 whitespace-nowrap">
-                  {tomorrowWorkout.runType ?? tomorrowWorkout.dayType}
-                </span>
-              </div>
-            </div>
-          )}
-        </div>
-      ) : displayEntry ? (
-        isPostRun ? (
-          <div className={`bg-white rounded-2xl border border-gray-100 border-l-4 ${runTypeBorderColor(displayEntry)} shadow-sm overflow-hidden mb-4`}>
-            <div className="p-5">
-              <div className="text-xs font-bold text-gray-400 tracking-wide mb-1">DONE</div>
-              <div className="text-xl font-bold text-gray-900 mb-3">
-                {displayEntry.workout ?? displayEntry.runType ?? displayEntry.dayType}
-              </div>
-              <div className="space-y-2">
-                <div className="flex items-start gap-3">
-                  <span className="text-xs font-semibold text-gray-400 w-14 shrink-0 pt-0.5">Planned</span>
-                  <span className="text-sm text-gray-500">
-                    {[
-                      displayEntry.distance && `${displayEntry.distance} mi`,
-                      displayEntry.targetPace && `${displayEntry.targetPace} /mi`,
-                      displayEntry.hrZone && `Z${displayEntry.hrZone}`,
-                      viewPhase?.name,
-                    ].filter(Boolean).join(' · ')}
-                  </span>
-                </div>
-                {runLog && (
-                  <div className="flex items-start gap-3">
-                    <span className="text-xs font-semibold text-gray-400 w-14 shrink-0 pt-0.5">Actual</span>
-                    <div className="text-sm font-semibold text-gray-900">
-                      {[
-                        runLog.distance && `${runLog.distance} mi`,
-                        runLog.pace && `${runLog.pace} /mi`,
-                        runLog.duration && `${runLog.duration} min`,
-                        runLog.avgHr && `${runLog.avgHr} bpm`,
-                      ].filter(Boolean).join(' · ')}
-                      {distanceDelta != null && Math.abs(distanceDelta) > 0.5 && (
-                        <span className={`ml-2 text-xs font-normal ${distanceDelta > 0 ? 'text-emerald-600' : 'text-amber-600'}`}>
-                          ({distanceDelta > 0 ? '+' : ''}{distanceDelta.toFixed(1)} mi)
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-            {/* Signal — embedded at bottom, hidden until tapped */}
-            <div className="border-t border-gray-100">
-              <button
-                onClick={() => setPostWorkoutExpanded(v => !v)}
-                className="w-full px-5 py-3 flex items-center justify-between text-left bg-gray-50 touch-manipulation"
-              >
-                <div className="flex items-center gap-2">
-                  <Radio size={13} className="text-emerald-600" />
-                  <span className="text-xs font-bold text-emerald-700 tracking-wide">The Signal</span>
-                  <span className="text-xs text-emerald-500">Asst. Coach</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span onClick={e => { e.stopPropagation(); handleGeneratePostNote() }}>
-                    <RefreshCw size={12} className={`text-emerald-400 hover:text-emerald-600 ${postNoteLoading ? 'animate-spin' : ''}`} />
-                  </span>
-                  {postWorkoutExpanded ? <ChevronUp size={14} className="text-gray-400" /> : <ChevronDown size={14} className="text-gray-400" />}
-                </div>
-              </button>
-              {postWorkoutExpanded && (
-                <div className="px-5 pb-5 pt-3 bg-emerald-50">
-                  {postNoteLoading ? (
-                    <p className="text-sm text-gray-400 italic">Generating...</p>
-                  ) : postNote ? (
-                    <>
-                      {postNote.verdict && (
-                        <p className="text-sm text-emerald-900 leading-snug mb-3">{postNote.verdict.replace(/\*+/g, '')}</p>
-                      )}
-                      <div className="prose prose-sm prose-slate max-w-none">
-                        <ReactMarkdown>{postNote.coachingTake}</ReactMarkdown>
-                      </div>
-                    </>
-                  ) : (
-                    <p className="text-sm text-gray-400 italic">Tap ↻ to generate analysis.</p>
-                  )}
-                </div>
-              )}
-            </div>
-          </div>
-        ) : (
-          <div className={`bg-white rounded-2xl border border-gray-100 border-l-4 ${runTypeBorderColor(displayEntry)} shadow-sm overflow-hidden mb-4`}>
-            <div className="p-5">
-              <div className="flex items-start justify-between gap-2 mb-2">
-                <div>
-                  <div className="text-xs font-bold text-gray-400 tracking-wide mb-1">
-                    {displayEntry.date === viewDate
-                      ? (isViewingToday ? 'TODAY' : 'THIS DAY')
-                      : `NEXT UP · ${new Date(displayEntry.date + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}`}
-                  </div>
-                  <div className="text-xl font-bold text-gray-900">
-                    {displayEntry.workout ?? displayEntry.runType ?? displayEntry.dayType}
-                  </div>
-                </div>
-                <div className="flex flex-col items-end gap-1.5 shrink-0">
-                  {effectiveLeaveBy && displayEntry.date === viewDate && (
-                    editingLeaveBy ? (
-                      <input
-                        type="time"
-                        defaultValue={runStartOverride ?? defaultRunStart ?? '06:30'}
-                        autoFocus
-                        className="text-xs border border-amber-200 rounded-lg px-2 py-1 bg-amber-50 text-amber-700 w-24"
-                        onBlur={e => {
-                          const val = e.target.value
-                          if (val) {
-                            setRunStartOverride(val)
-                            localStorage.setItem(`trainer-run-start-${today}`, val)
-                          }
-                          setEditingLeaveBy(false)
-                        }}
-                        onKeyDown={e => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
-                      />
-                    ) : (
-                      <button
-                        onClick={() => setEditingLeaveBy(true)}
-                        className="flex items-center gap-1 text-xs font-semibold text-amber-700 bg-amber-50 border border-amber-100 px-2 py-1 rounded-lg"
-                      >
-                        <Clock size={11} />
-                        Leave by {effectiveLeaveBy}
-                      </button>
-                    )
-                  )}
-                  <span className="text-xs font-semibold px-2.5 py-1 rounded-full bg-gray-100 text-gray-600 whitespace-nowrap">
-                    {displayEntry.runType ?? displayEntry.dayType}
-                  </span>
-                </div>
-              </div>
-              <div className="flex flex-wrap gap-3 text-sm text-gray-500 mb-3">
-                {displayEntry.distance && <span className="font-semibold text-gray-700">{displayEntry.distance} mi</span>}
-                {displayEntry.hrZone && <span>Zone {displayEntry.hrZone}</span>}
-                {displayEntry.targetPace && <span>{displayEntry.targetPace} /mi</span>}
-                {viewPhase && <span>{viewPhase.name}</span>}
-              </div>
-              {workoutInstructions && (() => {
-                const firstLine = workoutInstructions.split(/\n|\.(?:\s|$)/)[0].trim()
-                const hasMore = workoutInstructions.length > firstLine.length + 1
-                return (
-                  <div className="mb-3">
-                    <div className="text-sm text-gray-800 leading-relaxed font-mono">
-                      {instructionsExpanded ? workoutInstructions : firstLine}
-                    </div>
-                    {hasMore && (
-                      <button
-                        onClick={() => setInstructionsExpanded(v => !v)}
-                        className="mt-1 text-xs text-blue-500 hover:text-blue-700 flex items-center gap-0.5"
-                      >
-                        {instructionsExpanded ? <><ChevronUp size={12} /> Less</> : <><ChevronDown size={12} /> Full workout</>}
-                      </button>
-                    )}
-                  </div>
-                )
-              })()}
-              {workoutReason && (
-                <button
-                  onClick={() => setReasonExpanded(v => !v)}
-                  className="text-xs text-gray-400 hover:text-gray-600 flex items-center gap-1 mb-3"
-                >
-                  <span>Why this workout</span>
-                  <span>{reasonExpanded ? '▴' : '▾'}</span>
-                </button>
-              )}
-              {workoutReason && reasonExpanded && (
-                <div className="text-sm text-gray-500 leading-relaxed mb-3 pl-2 border-l-2 border-gray-100">
-                  {workoutReason}
-                </div>
-              )}
-            </div>
-            {showSyncPrompt && (
-              <div className="border-t border-amber-100 bg-amber-50 px-5 py-3">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-xs text-amber-700">After 1pm — did you run this morning?</span>
-                  <button
-                    onClick={handleSync}
-                    disabled={syncing}
-                    className="flex items-center gap-1.5 text-xs font-semibold text-amber-700 hover:text-amber-900 disabled:opacity-40"
-                  >
-                    <RefreshCw size={11} className={syncing ? 'animate-spin' : ''} />
-                    {syncing ? 'Syncing…' : 'Sync Strava'}
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-        )
-      ) : (
-        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5 mb-4">
-          <div className="text-sm text-gray-400 italic">No workout scheduled.</div>
-        </div>
-      )}
-
-      {displayEntry && displayEntry.notes && displayEntry.date === viewDate && (
-        <div className="bg-indigo-50 border border-indigo-100 rounded-2xl p-4 mb-4">
-          <div className="flex items-center gap-2 mb-2">
-            <Smile size={14} className="text-indigo-400" />
-            <div className="text-xs font-bold text-indigo-500 tracking-wide">Coach FouLox</div>
-          </div>
-          <p className="text-sm text-indigo-900 leading-relaxed">{displayEntry.notes}</p>
         </div>
       )}
 


### PR DESCRIPTION
## What

Adds photo capture to the Playbook quote drawer. Photograph a printed page — a book, RRCA materials, a clinic handout — and Claude reads it for you.

## Changes

- **From photo** button next to the Quote label in the drawer
- Tapping it opens the device rear camera (or photo library)
- Image is resized client-side to max 1200px before sending (keeps payload small)
- New `extractQuoteFromImage` server action sends the image to Claude vision and returns the extracted passage
- Extracted text pre-fills the Quote textarea, fully editable before saving
- Clear error message if extraction fails, coach can type manually
- Image is not stored — only the extracted text is saved

## Test on mobile

1. Open Coach > Playbook > Add Quote
2. Tap "From photo" next to the Quote label
3. Point at a printed page and take the photo
4. Wait a few seconds — "Reading photo..." shows while Claude processes
5. Extracted text should appear in the Quote field
6. Edit if needed, fill in author/source/tags, save
7. Also test the failure path: tap From photo, cancel — should handle gracefully

closes #46
