### PR TITLE
Show actual vs planned mileage in coach week view — story #33

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,11 +58,12 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
 ```
 
-## Screens (Bottom Nav — 4 tabs)
+## Screens (Bottom Nav — 5 tabs)
 1. **Today** (`/`) — Planned workout, AI coaching note (why it matters today), Apple Health snapshot (HRV/sleep), days to next race
 2. **Week** (`/week`) — This week's plan vs. actual, AI week-in-review, one-tap PT summary copy
 3. **Plan** (`/plan`) — Three sub-tabs: Weeks, Phases, Races
 4. **Library** (`/library`) — Workout library; add easy runs, long runs, quality workouts
+5. **Coach** (`/coach`) — Coach profile + Playbook (see below). Feedback link lives here, removed from nav.
 
 ## Plan Tab — Sub-tabs
 
@@ -95,6 +96,35 @@ NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
 - Adding a race also creates/updates a Race plan day for that date
 - Updating a race date resets the old date's plan day to Rest (via upsertPlanDay)
 - Deleting a race resets that date's plan day to Rest
+
+## Coach Tab — The Playbook (epic #40)
+
+Two sub-tabs: **Profile** and **Playbook**.
+
+### Profile
+- Fields: name, coaching philosophy, coaching influences (chip list), credentials
+- Persists to Vercel KV under key `coach:profile` (no expiry)
+- Philosophy and influences are fed into Claude system prompt for AI coaching notes
+
+### Playbook
+- Curated quote library — coach adds quotes from books, certifications, clinic materials
+- Each quote: text, author, source, topic tags, personal note ("why does this belong here?")
+- Captured by: text paste OR photographing a printed page (Claude vision extracts the text)
+- Photo flow: resized client-side to max 1200px → base64 → `extractQuoteFromImage` action → Claude vision → pre-fills quote field
+- Persists to Vercel KV under key `coach:playbook:quotes` as JSON array, newest first (no expiry)
+- Images are not stored — only extracted text is saved
+- Topic tags: Pacing, Threshold, Easy Running, Long Run, Recovery, Periodization, Race Prep, Mental, Strength, Nutrition
+- Attribution format: "[Quote]" — Author; Source
+
+### KV keys
+| Key | What |
+|-----|------|
+| `coach:profile` | CoachProfile JSON object |
+| `coach:playbook:quotes` | PlaybookQuote[] JSON array |
+
+### Components
+- `components/CoachClient.tsx` — tabbed coach section (profile + playbook)
+- `components/PlaybookQuoteDrawer.tsx` — add quote drawer (text or photo)
 
 ## AI Coaching — How It Works
 - **Nightly cron** (midnight ET): generates coaching notes for next 7 days of workouts, stores in Vercel KV
@@ -164,6 +194,17 @@ Every story ships as a PR, not a direct commit to `main`:
 7. **Prompt Lou to run `/ultrareview`** on any PR touching more than one file (see below)
 8. **Lou reviews and merges** — production deploys automatically
 
+### Testing standard
+
+| Layer | Requirement |
+|---|---|
+| `lib/*.ts` — data, sheets, AI, KV | **TDD required.** Write tests first, then implement. No story touching this layer is done until tests pass. |
+| `app/actions.ts` — server actions | Integration tests for every critical path (upsert, delete). At minimum: happy path + one failure case. |
+| API routes (`app/api/`) | Test happy path + one failure case. |
+| UI components | No unit tests. Verify by running the app. |
+
+**Proof of work:** For any story that touches `lib/` or `app/actions.ts`, the PR description must include a summary of what was tested and the test output (`npm test` or equivalent). The existing test suite lives in `lib/__tests__/`. Run with `npm test`.
+
 ### Self-review before every PR (mandatory)
 Before opening a PR, Claude must review its own diff and check:
 - [ ] Does the implementation match every AC in the story?
@@ -171,6 +212,7 @@ Before opening a PR, Claude must review its own diff and check:
 - [ ] Any security issues — unvalidated input, exposed secrets, injection risks?
 - [ ] Consistent with project conventions (server components, sheet write patterns, Tailwind classes)?
 - [ ] TypeScript clean — run `npx tsc --noEmit` and confirm zero errors
+- [ ] Tests written and passing for any `lib/` or `app/actions.ts` changes (see Testing standard above)
 - [ ] No dead code, debug logs, or temporary hacks left in
 
 If anything fails, fix it before opening the PR.
@@ -198,6 +240,14 @@ The `ready-to-build` label is Lou's to apply — it means Lou has reviewed the s
 
 ### Never commit directly to main
 All code changes go through a PR. The only exception is CLAUDE.md updates and documentation.
+
+### Session wrap-up (before closing)
+When Lou signals the session is ending, Claude runs this check before the conversation closes:
+- Did any architectural decisions get made that aren't in CLAUDE.md?
+- Did any workflow or process changes happen that aren't in memory?
+- Is there anything in this conversation that a future agent would need and can't find in git, GitHub, or CLAUDE.md?
+
+If yes to any: write it down first, then close. Also note which story is up next so the next session can orient immediately.
 
 ## Deployment Status
 - **Live at**: https://trainerv1.vercel.app

--- a/app/plan/page.tsx
+++ b/app/plan/page.tsx
@@ -1,11 +1,12 @@
-import { fetchPlanData, fetchLibrary } from '@/lib/sheets'
+import { fetchPlanData, fetchLibrary, fetchTrainingLog } from '@/lib/sheets'
 import PlanClient from '@/components/PlanClient'
 
 export default async function PlanPage() {
-  const [{ plan, phases, races }, library] = await Promise.all([
+  const [{ plan, phases, races }, library, log] = await Promise.all([
     fetchPlanData(),
     fetchLibrary(),
+    fetchTrainingLog(),
   ])
   const today = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' })
-  return <PlanClient plan={plan} phases={phases} races={races} library={library} today={today} />
+  return <PlanClient plan={plan} phases={phases} races={races} library={library} log={log} today={today} />
 }

--- a/components/PlanClient.tsx
+++ b/components/PlanClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { ChevronLeft, ChevronRight, Flag, Plus, Pencil, Trash2, X, ChevronDown } from 'lucide-react'
-import type { PlannedWorkout, Phase, Race, LibraryWorkout } from '@/lib/data'
+import type { PlannedWorkout, Phase, Race, LibraryWorkout, TrainingLogEntry } from '@/lib/data'
 import { RACE_TYPES } from '@/lib/data'
 import { createPhase, updatePhase, deletePhase, savePlanDay, setupPhaseDays, addRace, updateRace, deleteRace, applyWorkoutToWeekday } from '@/app/actions'
 
@@ -34,6 +34,7 @@ type Props = {
   phases: Phase[]
   races: Race[]
   library: LibraryWorkout[]
+  log: TrainingLogEntry[]
   today: string
 }
 
@@ -388,7 +389,7 @@ function DayEditor({
 
 // ── Main Component ────────────────────────────────────────────
 
-export default function PlanClient({ plan, phases, races, library, today }: Props) {
+export default function PlanClient({ plan, phases, races, library, log, today }: Props) {
   const router = useRouter()
   const [tab, setTab] = useState<'plan' | 'phases' | 'races'>('plan')
   const [propagateOffer, setPropagateOffer] = useState<{
@@ -447,6 +448,9 @@ export default function PlanClient({ plan, phases, races, library, today }: Prop
     ?? phases.find(p => p.startDate <= weekStart && p.endDate >= weekStart)
     ?? null
   const totalMiles = weekEntries.reduce((s, e) => s + (e.distance ?? 0), 0)
+  const weekLog = log.filter(e => e.date >= weekStart && e.date <= weekEnd)
+  const actualRunMiles = weekLog.filter(e => /run/i.test(e.activityType)).reduce((s, e) => s + (e.distance ?? 0), 0)
+  const actualBikeMiles = weekLog.filter(e => /ride/i.test(e.activityType)).reduce((s, e) => s + (e.distance ?? 0), 0)
 
   const sortedRaces = useMemo(() => [...races].sort((a, b) => a.date.localeCompare(b.date)), [races])
 
@@ -748,7 +752,14 @@ export default function PlanClient({ plan, phases, races, library, today }: Prop
                 <div className="bg-blue-50 border border-blue-100 rounded-2xl p-3 mb-4">
                   <div className="text-xs font-bold text-blue-600 tracking-wide mb-0.5">{phase.name.toUpperCase()}</div>
                   <div className="text-sm text-gray-600">{phase.goal}</div>
-                  {totalMiles > 0 && <div className="text-xs text-gray-400 mt-1">{totalMiles.toFixed(1)} mi planned this week</div>}
+                  {totalMiles > 0 && (
+                    <div className="text-xs text-gray-400 mt-1">
+                      {actualRunMiles > 0
+                        ? <>{actualRunMiles.toFixed(1)} / {totalMiles.toFixed(1)} mi run</>
+                        : <>{totalMiles.toFixed(1)} mi planned</>}
+                      {actualBikeMiles > 0 && <span className="ml-2">· Bike {actualBikeMiles.toFixed(1)} mi</span>}
+                    </div>
+                  )}
                 </div>
               )}
 


### PR DESCRIPTION
## Summary

- Adds `fetchTrainingLog` to the Plan page server component (parallel with existing fetches — no perf cost)
- Passes the full log down to `PlanClient` as a new `log: TrainingLogEntry[]` prop
- Computes `actualRunMiles` and `actualBikeMiles` for the viewed week using the same `/run/i` and `/ride/i` filter patterns as `WeekClient`
- When actual run miles exist, displays `X.X / Y.Y mi run` instead of `Y.Y mi planned`; bike shown as a separate suffix if present
- Falls back to `Y.Y mi planned` for future weeks with no log data

closes #33

## Test plan

- [ ] Navigate to Plan tab → Weeks view on a week with logged runs — confirm "actual / planned mi run" appears
- [ ] Navigate to a future week with no log data — confirm fallback "X.X mi planned" still shows
- [ ] If a week has both runs and a bike ride logged — confirm bike suffix appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)