### PR TITLE
Week-level notes — coach writes intent, athlete reads it — story #30

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache'
 import { fetchPlanData, fetchTrainingData, fetchTrainingLog } from '@/lib/sheets'
 import { generateCoachingNote, generateRestDayNote, generatePostWorkoutNote, generatePTSummaryForRange, generateWeekReview, sendCheckInMessage } from '@/lib/ai'
-import { getCoachingNote, setCoachingNote, getPostCoachingNote, setPostCoachingNote, getCheckIn, setCheckIn, getWeekReview, setWeekReview, setCoachProfile, getPlaybookQuotes, savePlaybookQuotes } from '@/lib/kv'
+import { getCoachingNote, setCoachingNote, getPostCoachingNote, setPostCoachingNote, getCheckIn, setCheckIn, getWeekReview, setWeekReview, setCoachProfile, getPlaybookQuotes, savePlaybookQuotes, getWeekNotes, saveWeekNotes } from '@/lib/kv'
 import type { CoachingNote, WeekReview, CheckInMessage, CoachProfile, PlaybookQuote } from '@/lib/data'
 
 export async function fetchCoachingNoteForDate(date: string): Promise<CoachingNote | null> {
@@ -611,6 +611,23 @@ export async function removePlaybookQuote(id: string): Promise<{ success: boolea
     return { success: true }
   } catch (e) {
     return { success: false, error: e instanceof Error ? e.message : 'Failed to delete quote' }
+  }
+}
+
+export async function saveWeekNote(weekStart: string, note: string): Promise<{ success: boolean; error?: string }> {
+  try {
+    const notes = await getWeekNotes()
+    if (note.trim()) {
+      notes[weekStart] = note.trim()
+    } else {
+      delete notes[weekStart]
+    }
+    await saveWeekNotes(notes)
+    revalidatePath('/plan')
+    revalidatePath('/week')
+    return { success: true }
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Failed to save note' }
   }
 }
 

--- a/app/plan/page.tsx
+++ b/app/plan/page.tsx
@@ -1,12 +1,14 @@
 import { fetchPlanData, fetchLibrary, fetchTrainingLog } from '@/lib/sheets'
+import { getWeekNotes } from '@/lib/kv'
 import PlanClient from '@/components/PlanClient'
 
 export default async function PlanPage() {
-  const [{ plan, phases, races }, library, log] = await Promise.all([
+  const [{ plan, phases, races }, library, log, weekNotes] = await Promise.all([
     fetchPlanData(),
     fetchLibrary(),
     fetchTrainingLog(),
+    getWeekNotes(),
   ])
   const today = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' })
-  return <PlanClient plan={plan} phases={phases} races={races} library={library} log={log} today={today} />
+  return <PlanClient plan={plan} phases={phases} races={races} library={library} log={log} weekNotes={weekNotes} today={today} />
 }

--- a/app/week/page.tsx
+++ b/app/week/page.tsx
@@ -1,5 +1,5 @@
 import { fetchPlanData, fetchTrainingData, fetchTrainingLog } from '@/lib/sheets'
-import { getWeekReview, setWeekReview } from '@/lib/kv'
+import { getWeekReview, setWeekReview, getWeekNotes } from '@/lib/kv'
 import { generateWeekReview } from '@/lib/ai'
 import WeekClient from '@/components/WeekClient'
 
@@ -20,10 +20,11 @@ export default async function WeekPage() {
   const today = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' })
   const { start, end } = getWeekBounds(today)
 
-  const [{ plan, phases, races }, { health, strava }, log] = await Promise.all([
+  const [{ plan, phases, races }, { health, strava }, log, weekNotes] = await Promise.all([
     fetchPlanData(),
     fetchTrainingData(),
     fetchTrainingLog(),
+    getWeekNotes(),
   ])
 
   const weekPlan = plan.filter(e => e.date >= start && e.date <= end)
@@ -51,6 +52,7 @@ export default async function WeekPage() {
       phases={phases}
       strava={strava}
       initialWeekReview={weekReview}
+      weekNotes={weekNotes}
     />
   )
 }

--- a/components/PlanClient.tsx
+++ b/components/PlanClient.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useState, useMemo, useTransition } from 'react'
+import { useState, useMemo, useTransition, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { ChevronLeft, ChevronRight, Flag, Plus, Pencil, Trash2, X, ChevronDown } from 'lucide-react'
 import type { PlannedWorkout, Phase, Race, LibraryWorkout, TrainingLogEntry } from '@/lib/data'
 import { RACE_TYPES } from '@/lib/data'
-import { createPhase, updatePhase, deletePhase, savePlanDay, setupPhaseDays, addRace, updateRace, deleteRace, applyWorkoutToWeekday } from '@/app/actions'
+import { createPhase, updatePhase, deletePhase, savePlanDay, setupPhaseDays, addRace, updateRace, deleteRace, applyWorkoutToWeekday, saveWeekNote } from '@/app/actions'
 
 // ── Formatting helpers ────────────────────────────────────────
 
@@ -35,6 +35,7 @@ type Props = {
   races: Race[]
   library: LibraryWorkout[]
   log: TrainingLogEntry[]
+  weekNotes: Record<string, string>
   today: string
 }
 
@@ -389,7 +390,7 @@ function DayEditor({
 
 // ── Main Component ────────────────────────────────────────────
 
-export default function PlanClient({ plan, phases, races, library, log, today }: Props) {
+export default function PlanClient({ plan, phases, races, library, log, weekNotes, today }: Props) {
   const router = useRouter()
   const [tab, setTab] = useState<'plan' | 'phases' | 'races'>('plan')
   const [propagateOffer, setPropagateOffer] = useState<{
@@ -405,6 +406,9 @@ export default function PlanClient({ plan, phases, races, library, log, today }:
   const [phaseModal, setPhaseModal] = useState<{ open: boolean; editing: Phase | null }>({ open: false, editing: null })
   const [dayEditing, setDayEditing] = useState<PlannedWorkout | null>(null)
   const [isPending, startTransition] = useTransition()
+  const [isEditingNote, setIsEditingNote] = useState(false)
+  const [noteText, setNoteText] = useState('')
+  const [isSavingNote, startSaveNote] = useTransition()
 
   // Week navigation — grouped by calendar week (Mon–Sun) so races and manually
   // added days with Week#=0 don't collapse everything into "Week 1"
@@ -444,6 +448,12 @@ export default function PlanClient({ plan, phases, races, library, log, today }:
   const { weekNum, entries: weekEntries } = weeks[weekIdx] ?? { weekNum: 1, entries: [] as PlannedWorkout[] }
   const weekStart = weekEntries[0]?.date ?? ''
   const weekEnd = weekEntries[weekEntries.length - 1]?.date ?? ''
+
+  useEffect(() => {
+    setNoteText(weekNotes[weekStart] ?? '')
+    setIsEditingNote(false)
+  }, [weekStart, weekNotes])
+
   const phase = phases.find(p => p.startDate <= weekStart && p.endDate >= weekEnd)
     ?? phases.find(p => p.startDate <= weekStart && p.endDate >= weekStart)
     ?? null
@@ -759,6 +769,50 @@ export default function PlanClient({ plan, phases, races, library, log, today }:
                         : <>{totalMiles.toFixed(1)} mi planned</>}
                       {actualBikeMiles > 0 && <span className="ml-2">· Bike {actualBikeMiles.toFixed(1)} mi</span>}
                     </div>
+                  )}
+                </div>
+              )}
+
+              {/* Week note */}
+              {weekStart && (
+                <div className="bg-amber-50 border border-amber-100 rounded-2xl p-3 mb-4">
+                  <div className="text-xs font-bold text-amber-600 tracking-wide mb-1">WEEK NOTE</div>
+                  {isEditingNote ? (
+                    <>
+                      <textarea
+                        className="w-full text-sm text-gray-700 bg-transparent resize-none outline-none leading-relaxed"
+                        rows={3}
+                        autoFocus
+                        value={noteText}
+                        onChange={e => setNoteText(e.target.value)}
+                        placeholder="What should this athlete focus on this week?"
+                      />
+                      <div className="flex gap-2 mt-2">
+                        <button
+                          onClick={() => startSaveNote(async () => {
+                            await saveWeekNote(weekStart, noteText)
+                            setIsEditingNote(false)
+                          })}
+                          disabled={isSavingNote}
+                          className="text-xs font-semibold text-amber-700 bg-amber-100 rounded-lg px-3 py-1 active:opacity-70 disabled:opacity-40"
+                        >
+                          {isSavingNote ? 'Saving…' : 'Save'}
+                        </button>
+                        <button
+                          onClick={() => { setNoteText(weekNotes[weekStart] ?? ''); setIsEditingNote(false) }}
+                          className="text-xs text-gray-400 px-2 py-1 active:opacity-70"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </>
+                  ) : (
+                    <button className="w-full text-left active:opacity-70" onClick={() => setIsEditingNote(true)}>
+                      {noteText
+                        ? <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">{noteText}</p>
+                        : <p className="text-sm text-amber-300 italic">Add a note for this week…</p>
+                      }
+                    </button>
                   )}
                 </div>
               )}

--- a/components/WeekClient.tsx
+++ b/components/WeekClient.tsx
@@ -69,10 +69,11 @@ type Props = {
   phases: Phase[]
   strava: StravaActivity[]
   initialWeekReview: WeekReview | null
+  weekNotes: Record<string, string>
 }
 
 export default function WeekClient({
-  today, initialWeekStart, plan, log, health, phases, strava, initialWeekReview,
+  today, initialWeekStart, plan, log, health, phases, strava, initialWeekReview, weekNotes,
 }: Props) {
   const [viewWeekStart, setViewWeekStart] = useState(initialWeekStart)
   const [weekReviews, setWeekReviews] = useState<Record<string, WeekReview | null>>(
@@ -205,6 +206,13 @@ export default function WeekClient({
         <div className="bg-blue-50 border border-blue-100 rounded-2xl p-4 mb-4">
           <div className="text-xs font-bold text-blue-600 tracking-wide mb-1">{currentPhase.name.toUpperCase()}</div>
           <div className="text-sm text-gray-700 leading-relaxed">{currentPhase.goal}</div>
+        </div>
+      )}
+
+      {weekNotes[viewWeekStart] && (
+        <div className="bg-amber-50 border border-amber-100 rounded-2xl p-4 mb-4">
+          <div className="text-xs font-bold text-amber-600 tracking-wide mb-1">WEEK NOTE</div>
+          <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">{weekNotes[viewWeekStart]}</p>
         </div>
       )}
 

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -56,3 +56,15 @@ export async function getPlaybookQuotes(): Promise<PlaybookQuote[]> {
 export async function savePlaybookQuotes(quotes: PlaybookQuote[]): Promise<void> {
   await kv.set('coach:playbook:quotes', quotes)
 }
+
+export async function getWeekNotes(): Promise<Record<string, string>> {
+  try {
+    return await kv.get<Record<string, string>>('week:notes') ?? {}
+  } catch {
+    return {}
+  }
+}
+
+export async function saveWeekNotes(notes: Record<string, string>): Promise<void> {
+  await kv.set('week:notes', notes)
+}


### PR DESCRIPTION
## Summary

- New KV key `week:notes` stores a `Record<string, string>` mapping week start dates to note text — one read fetches all, no expiry, same pattern as coach profile
- `saveWeekNote` server action updates the map and revalidates both `/plan` and `/week`
- **Coach side (Plan tab):** amber card below the phase card — tap to edit inline, Save/Cancel buttons, placeholder text when empty. Note text syncs via useEffect when the week changes.
- **Athlete side (/week page):** same amber card, read-only, only renders when a note exists

closes #30

## Test plan

- [ ] Open Plan tab → Weeks view, tap the week note card, type a note, save — confirm it persists on reload
- [ ] Navigate to a different week — confirm note field shows that week's note (or empty placeholder)
- [ ] Open /week page — confirm the note appears below the phase card for weeks that have one
- [ ] Weeks with no note: nothing shown on /week, placeholder shown on Plan tab
- [ ] Long note (paragraph): renders gracefully on mobile without overflow

Generated with Claude Code