### PR TITLE
Add PR body template check stub workflow

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -2,7 +2,7 @@ name: PR template check
 
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened, edited, synchronize, reopened]
 
 jobs:
   check-body:

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,9 @@
+name: PR template check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-body:
+    uses: foulox/.github/.github/workflows/pr-template-check.yml@main


### PR DESCRIPTION
## Summary

Adds this repo's stub for the account-wide PR-body template check (`foulox/claude-memory#59`). The stub calls the reusable workflow defined in `foulox/.github` (`foulox/.github/.github/workflows/pr-template-check.yml@main`) — validation logic lives in exactly one place, this file is boilerplate.

Depends on `foulox/.github#1` merging to `main` first — until then this check will fail to resolve the reusable workflow reference.

## Test plan

### Verified by Claude (automated)

- [x] `ruby -ryaml -e "YAML.load_file(...)"` against the new workflow file — parses cleanly (no CI test framework for Actions workflows in this repo)

### Please verify manually (Lou)

- [ ] After `foulox/.github#1` merges, confirm this repo's PRs show a "PR template check" status check (pass on a conforming body, fail — non-blocking — on a non-conforming one)
