### PR TITLE
Ignore per-project dispatch bookkeeping (claude-cross-profile#94)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 *.swp
+
+# per-project dispatch bookkeeping and session notes (claude-cross-profile#94)
+/dispatch/
+/.agent-sessions/


### PR DESCRIPTION
## What

Adds `dispatch/` and `.agent-sessions/` to `.gitignore` so this repo is ready for `agent-session`/`pm-dispatch`'s new per-project dispatch bookkeeping design (claude-cross-profile#94 — dispatch state moves from a centralized location to living inside each project repo).

## Why

Without this, the first `dispatch/` or `.agent-sessions/` write in this repo would show up as untracked/dirty in `git status`.

## Test plan (Claude)

- [x] Confirmed neither pattern was already covered
- [x] Confirmed the addition doesn't shadow any other intentionally-tracked path

## Manual steps (Lou)

- [ ] Merge whenever convenient — no urgency, this just needs to land before the first per-project dispatch write happens in this repo
